### PR TITLE
Updated kustomize build cmd

### DIFF
--- a/bootstrap/setup-cr.yaml
+++ b/bootstrap/setup-cr.yaml
@@ -87,7 +87,7 @@ data:
     spec:
       generate:
         command: ["sh", "-c"]
-        args: ["kustomize --enable-alpha-plugins build . | AVP_TYPE=sops argocd-vault-plugin generate -"]
+        args: ["kustomize build --enable-alpha-plugins . | AVP_TYPE=sops argocd-vault-plugin generate -"]
   kustomize-novault-plugin.yaml: |
     apiVersion: argoproj.io/v1alpha1
     kind: ConfigManagementPlugin
@@ -96,7 +96,7 @@ data:
     spec:
       generate:
         command: ["sh", "-c"]
-        args: ["kustomize --enable-alpha-plugins build ."]
+        args: ["kustomize build --enable-alpha-plugins ."]
   helm-novault-plugin.yaml: |
     apiVersion: argoproj.io/v1alpha1
     kind: ConfigManagementPlugin


### PR DESCRIPTION
Observed kustomize plugin was failing if `build` wasn't placed directly after `kustomize`.

Eg.
https://github.com/viaduct-ai/kustomize-sops/blob/master/README.md?plain=1#L175